### PR TITLE
fix: 랜딩페이지 디자인 피드백 수정

### DIFF
--- a/src/frameworks/web/components/atoms/Button/Button.tsx
+++ b/src/frameworks/web/components/atoms/Button/Button.tsx
@@ -51,6 +51,7 @@ const MobileWideButton = styled(BaseButton)`
   width: 100%;
   height: 70px;
   text-align: center;
+  border-radius: 0 0 20px 20px;
   color: ${(props) => props.color ?? theme.color.primary.Black};
 `;
 

--- a/src/frameworks/web/components/atoms/Label/Label.tsx
+++ b/src/frameworks/web/components/atoms/Label/Label.tsx
@@ -67,6 +67,27 @@ const LabelP2 = styled(BaseLabel)`
   line-height: 24px;
 `;
 
+const MobileLabelH1 = styled(BaseLabel)`
+  font-weight: 700;
+  font-size: 36px;
+  letter-spacing: -0.54;
+  line-height: 50px;
+`;
+
+const MobileLabelH2 = styled(BaseLabel)`
+  font-weight: 700;
+  font-size: 21px;
+  letter-spacing: -0.2;
+  line-height: 32px;
+`;
+
+const MobileLabelP2 = styled(BaseLabel)`
+  font-weight: 400;
+  font-size: 12px;
+  letter-spacing: 0;
+  line-height: 22px;
+`;
+
 const LabelMark = styled.mark`
   line-height: ${(props: ILabelMark) => ((props.mark === 'full') ? -1 : 0)}em;
   padding-left: 10px;
@@ -87,6 +108,12 @@ const LABEL = {
   H6: LabelH6,
   P1: LabelP1,
   P2: LabelP2,
+  MobileH1: MobileLabelH1,
+  MobileH2: MobileLabelH2,
+  MobileH3: LabelH5,
+  MobileH4: LabelH6,
+  MobileP1: LabelP2,
+  MobileP2: MobileLabelP2,
 };
 
 export default class Label extends React.PureComponent<ILabel> {

--- a/src/frameworks/web/components/molecules/DividedCard/DividedCard.stories.tsx
+++ b/src/frameworks/web/components/molecules/DividedCard/DividedCard.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { withKnobs, text } from '@storybook/addon-knobs';
 import DividedCard from 'frameworks/web/components/molecules/DividedCard/DividedCard';
-import { LabelP1 } from 'frameworks/web/components/atoms/Label/Label';
+import Label from 'frameworks/web/components/atoms/Label/Label';
 import theme from 'theme';
 
 export default {
@@ -18,14 +18,14 @@ export const SimpleTextDividedCard = () => {
     <DividedCard title={title}>
       {{
         left: (
-          <LabelP1 color={theme.color.primary.White}>
+          <Label type="P1" color={theme.color.primary.White}>
             {leftLabel}
-          </LabelP1>
+          </Label>
         ),
         right: (
-          <LabelP1>
+          <Label type="P1">
             {rightLabel}
-          </LabelP1>
+          </Label>
         ),
       }}
     </DividedCard>

--- a/src/frameworks/web/components/molecules/DividedCard/DividedCard.tsx
+++ b/src/frameworks/web/components/molecules/DividedCard/DividedCard.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import React, { ReactNode } from 'react';
 import theme from 'theme';
 import ContentsBox from 'frameworks/web/components/atoms/ContentsBox/ContentsBox';
-import { LabelH4 } from 'frameworks/web/components/atoms/Label/Label';
+import Label from 'frameworks/web/components/atoms/Label/Label';
 // eslint-disable-next-line no-unused-vars
 import { IDividedCard } from 'interfaces/frameworks/web/components/molecules/DividedCard/IDividedCard';
 
@@ -38,7 +38,7 @@ export default class DividedCard extends React.PureComponent<IDividedCard> {
     return (
       <CardContainer isDarkBackground={false}>
         <LeftContainer>
-          <LabelH4 color={theme.color.primary.White}>{title}</LabelH4>
+          <Label type="H4" color={theme.color.primary.White}>{title}</Label>
           {left}
         </LeftContainer>
         <RightContainer>

--- a/src/frameworks/web/components/molecules/SingleCard/SingleCard.stories.tsx
+++ b/src/frameworks/web/components/molecules/SingleCard/SingleCard.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { withKnobs, boolean, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import SingleCard from 'frameworks/web/components/molecules/SingleCard/SingleCard';
-import { LabelP1 } from 'frameworks/web/components/atoms/Label/Label';
+import Label from 'frameworks/web/components/atoms/Label/Label';
 import theme from 'theme';
 
 export default {
@@ -28,9 +28,9 @@ export const SimpleTextSingleCard = () => {
 
   return (
     <SingleCard title={title} buttonLabel={buttonLabel} buttonOnClick={buttonOnClick}>
-      <LabelP1 color={theme.color.secondary.Moon}>
+      <Label type="P1" color={theme.color.secondary.Moon}>
         {label}
-      </LabelP1>
+      </Label>
     </SingleCard>
   );
 };

--- a/src/frameworks/web/components/molecules/SingleCard/SingleCard.tsx
+++ b/src/frameworks/web/components/molecules/SingleCard/SingleCard.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import React, { ReactNode } from 'react';
 import theme from 'theme';
 import ContentsBox from 'frameworks/web/components/atoms/ContentsBox/ContentsBox';
-import { LabelH4 } from 'frameworks/web/components/atoms/Label/Label';
+import Label from 'frameworks/web/components/atoms/Label/Label';
 import Button from 'frameworks/web/components/atoms/Button/Button';
 // eslint-disable-next-line no-unused-vars
 import { ISingleCard } from 'interfaces/frameworks/web/components/molecules/SingleCard/ISingleCard';
@@ -46,7 +46,7 @@ export default class SingleCard extends React.PureComponent<ISingleCard> {
     });
     return (
       <CardContainer isDarkBackground={false}>
-        <LabelH4 color={theme.color.primary.Azure}>{title}</LabelH4>
+        <Label type="H4" color={theme.color.primary.Azure}>{title}</Label>
         <ContextContainer>
           {children}
         </ContextContainer>

--- a/src/frameworks/web/components/organisms/Footer/Footer.tsx
+++ b/src/frameworks/web/components/organisms/Footer/Footer.tsx
@@ -74,7 +74,7 @@ export default class Footer extends React.PureComponent {
                 <CodeClubLogo src="codeclub.svg" alt="footer code-club icon" />
               </a>
             </div>
-            <Label type="P2" color={theme.color.secondary.Moon} style={{ marginTop: '8px', textAlign: 'center' }}>
+            <Label type="MobileP2" color={theme.color.secondary.Moon} style={{ marginTop: '8px', textAlign: 'center' }}>
               Copyright © 2020 Colored by Software, All rights reserved.
             </Label>
           </FooterCenterContainer>

--- a/src/frameworks/web/components/organisms/Footer/Footer.tsx
+++ b/src/frameworks/web/components/organisms/Footer/Footer.tsx
@@ -6,9 +6,13 @@ import {
   Row, Col, Visible, Hidden,
 } from 'react-grid-system';
 
+const MaxContainer = styled.div`
+  max-width: 1280px;
+  margin: 0 auto;
+`;
+
 const FooterContainer = styled.div`
-  height: 144px;
-  padding: 0 85px;
+  padding: 40px 54px;
   background: ${theme.color.primary.Black};
 `;
 
@@ -26,7 +30,7 @@ const CodeClubLogo = styled.img`
 
 const FooterCenterContainer = styled.div`
   width: 100%;
-  height: 100%;
+  height: ;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -36,50 +40,54 @@ const FooterCenterContainer = styled.div`
 export default class Footer extends React.PureComponent {
   render() {
     return (
-      <FooterContainer>
-        <Visible lg xl>
-          <Row align="center" justify="between" style={{ height: '100%', margin: '0' }}>
-            <Col md={4}>
-              <Label type="H5" color={theme.color.secondary.Moon}>소프트웨어에 물들다</Label>
-              <Label type="P2" color={theme.color.secondary.Moon}>Colored in Software</Label>
-            </Col>
-            <Col lg={6}>
-              <div style={{ float: 'right', marginLeft: '230px' }}>
-                <a href="https://www.facebook.com/groups/may.somul/">
-                  <FooterSNSLogo src="facebook-footer.svg" alt="footer facebook icon" />
-                </a>
-                <a href="https://github.com/somul-project">
-                  <FooterSNSLogo src="github-footer.svg" alt="footer github icon" />
-                </a>
-                <a href="https://codeclubkorea.org">
-                  <CodeClubLogo src="codeclub.svg" alt="footer code-club icon" />
-                </a>
-              </div>
-              <Label type="P2" color={theme.color.secondary.Moon} style={{ float: 'right' }}>
-                Copyright © 2020 Colored by Software, All rights reserved.
-              </Label>
-            </Col>
-          </Row>
-        </Visible>
-        <Hidden lg xl>
-          <FooterCenterContainer>
-            <div>
-              <a href="https://www.facebook.com/groups/may.somul/">
-                <FooterSNSLogo src="facebook-footer.svg" alt="footer facebook icon" />
-              </a>
-              <a href="https://github.com/somul-project">
-                <FooterSNSLogo src="github-footer.svg" alt="footer github icon" />
-              </a>
-              <a href="https://codeclubkorea.org">
-                <CodeClubLogo src="codeclub.svg" alt="footer code-club icon" />
-              </a>
-            </div>
-            <Label type="MobileP2" color={theme.color.secondary.Moon} style={{ marginTop: '8px', textAlign: 'center' }}>
-              Copyright © 2020 Colored by Software, All rights reserved.
-            </Label>
-          </FooterCenterContainer>
-        </Hidden>
-      </FooterContainer>
+      <div style={{ background: theme.color.primary.Black }}>
+        <MaxContainer>
+          <FooterContainer>
+            <Visible lg xl>
+              <Row align="center" justify="between" style={{ height: '100%', margin: '0' }}>
+                <Col md={4}>
+                  <Label type="H5" color={theme.color.secondary.Moon}>소프트웨어에 물들다</Label>
+                  <Label type="P2" color={theme.color.secondary.Moon}>Colored in Software</Label>
+                </Col>
+                <Col lg={6}>
+                  <div style={{ float: 'right', marginLeft: '230px' }}>
+                    <a href="https://www.facebook.com/groups/may.somul/">
+                      <FooterSNSLogo src="facebook-footer.svg" alt="footer facebook icon" />
+                    </a>
+                    <a href="https://github.com/somul-project">
+                      <FooterSNSLogo src="github-footer.svg" alt="footer github icon" />
+                    </a>
+                    <a href="https://codeclubkorea.org">
+                      <CodeClubLogo src="codeclub.svg" alt="footer code-club icon" />
+                    </a>
+                  </div>
+                  <Label type="P2" color={theme.color.secondary.Moon} style={{ float: 'right' }}>
+                    Copyright © 2020 Colored by Software, All rights reserved.
+                  </Label>
+                </Col>
+              </Row>
+            </Visible>
+            <Hidden lg xl>
+              <FooterCenterContainer>
+                <div>
+                  <a href="https://www.facebook.com/groups/may.somul/">
+                    <FooterSNSLogo src="facebook-footer.svg" alt="footer facebook icon" />
+                  </a>
+                  <a href="https://github.com/somul-project">
+                    <FooterSNSLogo src="github-footer.svg" alt="footer github icon" />
+                  </a>
+                  <a href="https://codeclubkorea.org">
+                    <CodeClubLogo src="codeclub.svg" alt="footer code-club icon" />
+                  </a>
+                </div>
+                <Label type="MobileP2" color={theme.color.secondary.Moon} style={{ marginTop: '8px', textAlign: 'center' }}>
+                  Copyright © 2020 Colored by Software, All rights reserved.
+                </Label>
+              </FooterCenterContainer>
+            </Hidden>
+          </FooterContainer>
+        </MaxContainer>
+      </div>
     );
   }
 }

--- a/src/frameworks/web/components/organisms/Header/Header.tsx
+++ b/src/frameworks/web/components/organisms/Header/Header.tsx
@@ -36,58 +36,62 @@ const notYetAlert = () => {
 export default class Header extends React.PureComponent {
   render() {
     return (
-      <ScreenClassRender render={(sClass: string) => (
-        <div style={{
-          height: sClass === 'xs' ? '48px' : '80px',
-          margin: sClass === 'xs' ? '0 24px' : '0 85px',
-        }}
-        >
-          <a href="https://somul.kr">
-            <img
-              src="logo.svg"
-              alt="소프트웨어에 물들다 (로고)"
-              style={{
-                margin: sClass === 'xs' ? '16px 0' : '30px 76px 30px 0',
-                width: sClass === 'xs' ? '90px' : '112.5px',
-                height: sClass === 'xs' ? '16px' : '20px',
-                float: 'left',
-              }}
-            />
-          </a>
-          <Visible xl>
-            <HeaderMenuContainer>
-              <a href="#landingAbout" style={{ textDecoration: 'none' }}>
-                <Label type="H5" onClick={notYetAlert}>소물이란?</Label>
+      <div>
+        <ScreenClassRender render={(sClass: string) => (
+          <div style={{ maxWidth: '1280px', margin: '0 auto' }}>
+            <div style={{
+              height: sClass === 'xs' ? '48px' : '80px',
+              margin: sClass === 'xs' ? '0 24px' : '0 85px',
+            }}
+            >
+              <a href="https://somul.kr">
+                <img
+                  src="logo.svg"
+                  alt="소프트웨어에 물들다 (로고)"
+                  style={{
+                    margin: sClass === 'xs' ? '16px 0' : '30px 76px 30px 0',
+                    width: sClass === 'xs' ? '90px' : '112.5px',
+                    height: sClass === 'xs' ? '16px' : '20px',
+                    float: 'left',
+                  }}
+                />
               </a>
-              <Label type="H5" onClick={notYetAlert}>강연정보</Label>
-              <a href="#landingJoin" style={{ textDecoration: 'none' }}>
-                <Label type="H5">참가신청</Label>
-              </a>
-              <a href="#landingSponsor" style={{ textDecoration: 'none' }}>
-                <Label type="H5">후원안내</Label>
-              </a>
-              <Label type="H5" onClick={notYetAlert}>FAQ</Label>
-            </HeaderMenuContainer>
-            <HeaderButtonContainer>
-              <Button type="small" label="회원가입" isPrimary={false} onClick={notYetAlert} style={{ marginLeft: '20px' }} />
-              <Button type="small" label="로그인" isPrimary onClick={notYetAlert} />
-            </HeaderButtonContainer>
-          </Visible>
-          <Hidden xl>
-            <HeaderSidebarButton
-              src="mobile-menu.svg"
-              alt="사이드 메뉴"
-              onClick={notYetAlert}
-              style={{
-                width: sClass === 'xs' ? '20px' : '40px',
-                height: sClass === 'xs' ? '20px' : '40px',
-                margin: sClass === 'xs' ? '14px 0' : '20px 0',
-              }}
-            />
-          </Hidden>
-        </div>
-      )}
-      />
+              <Visible xl>
+                <HeaderMenuContainer>
+                  <a href="#landingAbout" style={{ textDecoration: 'none' }}>
+                    <Label type="H5" onClick={notYetAlert}>소물이란?</Label>
+                  </a>
+                  <Label type="H5" onClick={notYetAlert}>강연정보</Label>
+                  <a href="#landingJoin" style={{ textDecoration: 'none' }}>
+                    <Label type="H5">참가신청</Label>
+                  </a>
+                  <a href="#landingSponsor" style={{ textDecoration: 'none' }}>
+                    <Label type="H5">후원안내</Label>
+                  </a>
+                  <Label type="H5" onClick={notYetAlert}>FAQ</Label>
+                </HeaderMenuContainer>
+                <HeaderButtonContainer>
+                  <Button type="small" label="회원가입" isPrimary={false} onClick={notYetAlert} style={{ marginLeft: '20px' }} />
+                  <Button type="small" label="로그인" isPrimary onClick={notYetAlert} />
+                </HeaderButtonContainer>
+              </Visible>
+              <Hidden xl>
+                <HeaderSidebarButton
+                  src="mobile-menu.svg"
+                  alt="사이드 메뉴"
+                  onClick={notYetAlert}
+                  style={{
+                    width: sClass === 'xs' ? '20px' : '40px',
+                    height: sClass === 'xs' ? '20px' : '40px',
+                    margin: sClass === 'xs' ? '14px 0' : '20px 0',
+                  }}
+                />
+              </Hidden>
+            </div>
+          </div>
+        )}
+        />
+      </div>
     );
   }
 }

--- a/src/frameworks/web/components/organisms/Landing/LandingAbout.tsx
+++ b/src/frameworks/web/components/organisms/Landing/LandingAbout.tsx
@@ -4,6 +4,11 @@ import theme from 'theme';
 import Label from 'frameworks/web/components/atoms/Label/Label';
 import { Row, Col, ScreenClassRender } from 'react-grid-system';
 
+const MaxContainer = styled.div`
+  max-width: 1280px;
+  margin: 0 auto;
+`;
+
 const AboutIllust = styled.img`
   max-width: 635px;
   max-height: 315px;
@@ -16,60 +21,62 @@ const AboutIllust = styled.img`
 export default class LandingAbout extends React.PureComponent {
   render() {
     return (
-      <ScreenClassRender render={(sClass: string) => (
-        <div id="landingAbout">
-          <div
-            style={{
-              textAlign: 'center',
-              padding: ['lg', 'xl'].includes(sClass) ? '64px 0' : '33px 0 25px 0',
-            }}
-          >
-            <Label
-              type={['lg', 'xl'].includes(sClass) ? 'H4' : 'MobileH3'}
-              color={theme.color.primary.Azure}
-            >
-              ABOUT SOMUL
-            </Label>
-          </div>
-          <Row
-            justify="center"
-            align="center"
-            style={{ margin: ['lg', 'xl'].includes(sClass) ? '0 0 110px 0' : '0 0 48px 0' }}
-          >
-            <Col xs={10} md={8} lg={6}>
-              <AboutIllust src="about-illustration.png" alt="About Somul" />
-            </Col>
-            <Col
-              xs={10}
-              lg={4}
+      <MaxContainer>
+        <ScreenClassRender render={(sClass: string) => (
+          <div id="landingAbout">
+            <div
               style={{
-                textAlign: ['lg', 'xl'].includes(sClass) ? 'left' : 'center',
-                whiteSpace: 'pre-line',
+                textAlign: 'center',
+                padding: ['lg', 'xl'].includes(sClass) ? '64px 0' : '33px 0 25px 0',
               }}
             >
               <Label
-                type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}
-                style={{ paddingTop: ['lg', 'xl'].includes(sClass) ? '0' : '30px' }}
+                type={['lg', 'xl'].includes(sClass) ? 'H4' : 'MobileH3'}
+                color={theme.color.primary.Azure}
               >
-                &apos;소프트웨어에 물들다&apos;는 전국의 도서관에서 소프트웨어를 주제로
-                {sClass === 'md' ? '\n' : ' '}
-                한날 한시에 진행되는 강연 프로젝트입니다.
+                ABOUT SOMUL
               </Label>
-              <div style={{ padding: '12px 0' }} />
-              <Label
-                type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}
-                mark="full"
-                markColor="#FFF0A6"
+            </div>
+            <Row
+              justify="center"
+              align="center"
+              style={{ margin: ['lg', 'xl'].includes(sClass) ? '0 0 110px 0' : '0 0 48px 0' }}
+            >
+              <Col xs={10} md={8} lg={6}>
+                <AboutIllust src="about-illustration.png" alt="About Somul" />
+              </Col>
+              <Col
+                xs={10}
+                lg={4}
+                style={{
+                  textAlign: ['lg', 'xl'].includes(sClass) ? 'left' : 'center',
+                  whiteSpace: 'pre-line',
+                }}
               >
-                올해는 COVID-19 바이러스(이하 코로나)로 인하여 온라인으로 진행합니다.
-                {sClass === 'md' ? '\n' : ' '}
-                5월 29일 오후 2시에 공개될 강연 리스트(유튜브 링크)로 여러분들을 찾아뵙겠습니다.
-              </Label>
-            </Col>
-          </Row>
-        </div>
-      )}
-      />
+                <Label
+                  type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}
+                  style={{ paddingTop: ['lg', 'xl'].includes(sClass) ? '0' : '30px' }}
+                >
+                  &apos;소프트웨어에 물들다&apos;는 전국의 도서관에서 소프트웨어를 주제로
+                  {sClass === 'md' ? '\n' : ' '}
+                  한날 한시에 진행되는 강연 프로젝트입니다.
+                </Label>
+                <div style={{ padding: '12px 0' }} />
+                <Label
+                  type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}
+                  mark="full"
+                  markColor="#FFF0A6"
+                >
+                  올해는 COVID-19 바이러스(이하 코로나)로 인하여 온라인으로 진행합니다.
+                  {sClass === 'md' ? '\n' : ' '}
+                  5월 29일 오후 2시에 공개될 강연 리스트(유튜브 링크)로 여러분들을 찾아뵙겠습니다.
+                </Label>
+              </Col>
+            </Row>
+          </div>
+        )}
+        />
+      </MaxContainer>
     );
   }
 }

--- a/src/frameworks/web/components/organisms/Landing/LandingAbout.tsx
+++ b/src/frameworks/web/components/organisms/Landing/LandingAbout.tsx
@@ -24,7 +24,12 @@ export default class LandingAbout extends React.PureComponent {
               padding: ['lg', 'xl'].includes(sClass) ? '64px 0' : '33px 0 25px 0',
             }}
           >
-            <Label type="H4" color={theme.color.primary.Azure}>ABOUT SOMUL</Label>
+            <Label
+              type={['lg', 'xl'].includes(sClass) ? 'H4' : 'MobileH3'}
+              color={theme.color.primary.Azure}
+            >
+              ABOUT SOMUL
+            </Label>
           </div>
           <Row
             justify="center"
@@ -42,13 +47,20 @@ export default class LandingAbout extends React.PureComponent {
                 whiteSpace: 'pre-line',
               }}
             >
-              <Label type="P1" style={{ paddingTop: ['lg', 'xl'].includes(sClass) ? '0' : '30px' }}>
+              <Label
+                type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}
+                style={{ paddingTop: ['lg', 'xl'].includes(sClass) ? '0' : '30px' }}
+              >
                 &apos;소프트웨어에 물들다&apos;는 전국의 도서관에서 소프트웨어를 주제로
                 {sClass === 'md' ? '\n' : ' '}
                 한날 한시에 진행되는 강연 프로젝트입니다.
               </Label>
               <div style={{ padding: '12px 0' }} />
-              <Label type="P1" mark="full">
+              <Label
+                type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}
+                mark="full"
+                markColor="#FFF0A6"
+              >
                 올해는 COVID-19 바이러스(이하 코로나)로 인하여 온라인으로 진행합니다.
                 {sClass === 'md' ? '\n' : ' '}
                 5월 29일 오후 2시에 공개될 강연 리스트(유튜브 링크)로 여러분들을 찾아뵙겠습니다.

--- a/src/frameworks/web/components/organisms/Landing/LandingBanner.tsx
+++ b/src/frameworks/web/components/organisms/Landing/LandingBanner.tsx
@@ -11,15 +11,20 @@ const BannerContainer = styled.div`
   background-color: ${theme.color.primary.Azure};
 `;
 
+const MaxContainer = styled.div`
+  max-width: 1280px;
+  margin: 0 auto;
+`;
+
 const BannerTitleImg = styled.img`
   max-width: 430px;
   max-height: 175px;
   width: 100%;
   height: auto;
+  display: block;
 `;
 
 const BannerMainIllust = styled.img`
-  float: right;
   max-width: 589px;
   max-height: 526px;
   width: 100%;
@@ -29,64 +34,73 @@ const BannerMainIllust = styled.img`
 export default class LandingBanner extends React.PureComponent {
   render() {
     return (
-      <ScreenClassRender render={(sClass: string) => (
-        <BannerContainer>
-          <Row
-            justify={['lg', 'xl'].includes(sClass) ? 'center' : 'around'}
-            align={['lg', 'xl'].includes(sClass) ? 'start' : 'end'}
-            style={{
-              width: '100%',
-              paddingTop: ['lg', 'xl'].includes(sClass) ? '120px' : '32px',
-              paddingBottom: ['lg', 'xl'].includes(sClass) ? '80px' : '23px',
-              margin: '0',
-            }}
-          >
-            <Col offset={{ lg: 1 }} xs={6} sm={5} lg={4}>
-              <BannerTitleImg src="main-contents-title.svg" alt="소프트웨어에 물들다" />
-              <Visible lg xl>
-                <Label type="H4" color={theme.color.primary.White} style={{ margin: '40px 0' }}>
-                  2020년 05월 30일 14:00 ~
-                </Label>
-                <a href="#landingAbout"><Button isPrimary={false} label="자세히보기" onClick={() => undefined} /></a>
-              </Visible>
-            </Col>
-            <Hidden lg xl>
-              <Col xs={5}>
-                <Label type="MobileP1" color={theme.color.primary.White} style={{ textAlign: 'right' }}>
-                  2020년 05월 30일
-                  <br />
-                  14:00 ~
-                </Label>
-              </Col>
-            </Hidden>
-            <Col
-              offset={{ xs: 1 }}
-              xs={9}
-              lg={5}
+      <div style={{ backgroundColor: theme.color.primary.Azure }}>
+        <MaxContainer>
+          <ScreenClassRender render={(sClass: string) => (
+            <BannerContainer
               style={{
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'center',
-                marginTop: ['lg', 'xl'].includes(sClass) ? '0' : '32px',
+                margin: ['lg', 'xl'].includes(sClass) ? '0 110px 0 180px' : '0 16px',
               }}
             >
-              <BannerMainIllust src="main-illustration.png" alt="배너 이미지" />
-            </Col>
-          </Row>
-          <Hidden lg xl>
-            <div style={{
-              display: 'flex',
-              justifyContent: 'center',
-              width: '100%',
-              paddingBottom: '40px',
-            }}
-            >
-              <a href="#landingAbout"><Button isPrimary={false} label="자세히보기" onClick={() => undefined} /></a>
-            </div>
-          </Hidden>
-        </BannerContainer>
-      )}
-      />
+              <Row
+                justify={['lg', 'xl'].includes(sClass) ? 'between' : 'center'}
+                align={['lg', 'xl'].includes(sClass) ? 'start' : 'end'}
+                style={{
+                  width: '100%',
+                  paddingTop: ['lg', 'xl'].includes(sClass) ? '120px' : '32px',
+                  paddingBottom: ['lg', 'xl'].includes(sClass) ? '80px' : '23px',
+                  margin: '0',
+                }}
+              >
+                <Col xs={12} sm={12} lg={6} style={{ textAlign: ['lg', 'xl'].includes(sClass) ? 'initial' : 'center' }}>
+                  <BannerTitleImg src="main-contents-title.svg" alt="소프트웨어에 물들다" />
+                  <Visible lg xl>
+                    <Label type="H4" color={theme.color.primary.White} style={{ margin: '40px 0' }}>
+                      2020년 05월 30일 14:00 ~
+                    </Label>
+                    <a href="#landingAbout"><Button isPrimary={false} label="자세히보기" onClick={() => undefined} /></a>
+                  </Visible>
+                </Col>
+                <Hidden lg xl>
+                  <Col xs={12}>
+                    <Label type={['xs', 'sm'].includes(sClass) ? 'MobileP1' : 'H4'} color={theme.color.primary.White} style={{ textAlign: 'center', marginTop: '32px' }}>
+                      2020년 05월 30일 14:00 ~
+                    </Label>
+                  </Col>
+                </Hidden>
+                <Col
+                  xs={12}
+                  lg={6}
+                  style={{
+                    marginTop: ['lg', 'xl'].includes(sClass) ? '0' : '32px',
+                    textAlign: ['lg', 'xl'].includes(sClass) ? 'initial' : 'center',
+                  }}
+                >
+                  <BannerMainIllust
+                    src="main-illustration.png"
+                    alt="배너 이미지"
+                    style={{
+                      float: ['lg', 'xl'].includes(sClass) ? 'right' : 'none',
+                    }}
+                  />
+                </Col>
+              </Row>
+              <Hidden lg xl>
+                <div style={{
+                  display: 'flex',
+                  justifyContent: 'center',
+                  width: '100%',
+                  paddingBottom: '40px',
+                }}
+                >
+                  <a href="#landingAbout"><Button isPrimary={false} label="자세히보기" onClick={() => undefined} /></a>
+                </div>
+              </Hidden>
+            </BannerContainer>
+          )}
+          />
+        </MaxContainer>
+      </div>
     );
   }
 }

--- a/src/frameworks/web/components/organisms/Landing/LandingBanner.tsx
+++ b/src/frameworks/web/components/organisms/Landing/LandingBanner.tsx
@@ -9,6 +9,8 @@ import {
 
 const BannerContainer = styled.div`
   background-color: ${theme.color.primary.Azure};
+  background-image: url("main-illustration.png");
+  background-repeat: no-repeat;
 `;
 
 const MaxContainer = styled.div`
@@ -24,80 +26,77 @@ const BannerTitleImg = styled.img`
   display: block;
 `;
 
-const BannerMainIllust = styled.img`
-  max-width: 589px;
-  max-height: 526px;
-  width: 100%;
-  height: auto;
-`;
-
 export default class LandingBanner extends React.PureComponent {
   render() {
     return (
       <div style={{ backgroundColor: theme.color.primary.Azure }}>
         <MaxContainer>
-          <ScreenClassRender render={(sClass: string) => (
-            <BannerContainer
-              style={{
-                margin: ['lg', 'xl'].includes(sClass) ? '0 110px 0 180px' : '0 16px',
-              }}
-            >
-              <Row
-                justify={['lg', 'xl'].includes(sClass) ? 'between' : 'center'}
-                align={['lg', 'xl'].includes(sClass) ? 'start' : 'end'}
+          <ScreenClassRender render={(sClass: string) => {
+            // xs, sm : 2, md : 1, lg, xl: 0
+            let sClassNum: number;
+            let contentPadding: string;
+            let imgPosition: string;
+            if (['lg', 'xl'].includes(sClass)) {
+              sClassNum = 0;
+              contentPadding = '120px 0 253px 0';
+              imgPosition = 'right 114px';
+            } else if (sClass === 'md') {
+              sClassNum = 1;
+              contentPadding = '64px 0 533px 57px';
+              imgPosition = 'right 339px';
+            } else {
+              sClassNum = 2;
+              contentPadding = '32px 0 348px 0';
+              imgPosition = 'center 65%';
+            }
+            return (
+              <BannerContainer
                 style={{
-                  width: '100%',
-                  paddingTop: ['lg', 'xl'].includes(sClass) ? '120px' : '32px',
-                  paddingBottom: ['lg', 'xl'].includes(sClass) ? '80px' : '23px',
-                  margin: '0',
+                  margin: sClassNum === 0 ? '0 110px 0 180px' : '0 16px',
+                  backgroundPosition: imgPosition,
+                  backgroundSize: sClassNum === 2 ? '328px 293px' : '589px 526px',
                 }}
               >
-                <Col xs={12} sm={12} lg={6} style={{ textAlign: ['lg', 'xl'].includes(sClass) ? 'initial' : 'center' }}>
-                  <BannerTitleImg src="main-contents-title.svg" alt="소프트웨어에 물들다" />
-                  <Visible lg xl>
-                    <Label type="H4" color={theme.color.primary.White} style={{ margin: '40px 0' }}>
-                      2020년 05월 30일 14:00 ~
-                    </Label>
-                    <a href="#landingAbout"><Button isPrimary={false} label="자세히보기" onClick={() => undefined} /></a>
-                  </Visible>
-                </Col>
-                <Hidden lg xl>
-                  <Col xs={12}>
-                    <Label type={['xs', 'sm'].includes(sClass) ? 'MobileP1' : 'H4'} color={theme.color.primary.White} style={{ textAlign: 'center', marginTop: '32px' }}>
-                      2020년 05월 30일 14:00 ~
-                    </Label>
-                  </Col>
-                </Hidden>
-                <Col
-                  xs={12}
-                  lg={6}
+                <Row
+                  justify={sClassNum === 0 ? 'between' : 'center'}
+                  align={sClassNum === 0 ? 'start' : 'end'}
                   style={{
-                    marginTop: ['lg', 'xl'].includes(sClass) ? '0' : '32px',
-                    textAlign: ['lg', 'xl'].includes(sClass) ? 'initial' : 'center',
+                    width: '100%',
+                    padding: contentPadding,
+                    margin: '0',
                   }}
                 >
-                  <BannerMainIllust
-                    src="main-illustration.png"
-                    alt="배너 이미지"
-                    style={{
-                      float: ['lg', 'xl'].includes(sClass) ? 'right' : 'none',
-                    }}
-                  />
-                </Col>
-              </Row>
-              <Hidden lg xl>
-                <div style={{
-                  display: 'flex',
-                  justifyContent: 'center',
-                  width: '100%',
-                  paddingBottom: '40px',
-                }}
-                >
-                  <a href="#landingAbout"><Button isPrimary={false} label="자세히보기" onClick={() => undefined} /></a>
-                </div>
-              </Hidden>
-            </BannerContainer>
-          )}
+                  <Col xs={12} sm={12} lg={9} style={{ textAlign: sClassNum === 2 ? 'center' : 'initial' }}>
+                    <BannerTitleImg src="main-contents-title.svg" alt="소프트웨어에 물들다" />
+                    <Hidden xs sm>
+                      <Label type="H4" color={theme.color.primary.White} style={{ margin: '40px 0' }}>
+                        2020년 05월 30일 14:00 ~
+                      </Label>
+                      <a href="#landingAbout"><Button isPrimary={false} label="자세히보기" onClick={() => undefined} /></a>
+                    </Hidden>
+                  </Col>
+                  <Visible xs sm>
+                    <Col xs={12}>
+                      <Label type={sClassNum === 2 ? 'MobileP1' : 'H4'} color={theme.color.primary.White} style={{ textAlign: 'center', marginTop: '32px' }}>
+                        2020년 05월 30일 14:00 ~
+                      </Label>
+                    </Col>
+                  </Visible>
+                </Row>
+                <Visible xs sm>
+                  <div style={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    width: '100%',
+                    paddingBottom: '40px',
+                  }}
+                  >
+                    <a href="#landingAbout"><Button isPrimary={false} label="자세히보기" onClick={() => undefined} /></a>
+                  </div>
+                </Visible>
+              </BannerContainer>
+            );
+          }}
           />
         </MaxContainer>
       </div>

--- a/src/frameworks/web/components/organisms/Landing/LandingBanner.tsx
+++ b/src/frameworks/web/components/organisms/Landing/LandingBanner.tsx
@@ -52,7 +52,7 @@ export default class LandingBanner extends React.PureComponent {
             </Col>
             <Hidden lg xl>
               <Col xs={5}>
-                <Label type={sClass === 'xs' ? 'P2' : 'H4'} color={theme.color.primary.White} style={{ textAlign: 'right' }}>
+                <Label type="MobileP1" color={theme.color.primary.White} style={{ textAlign: 'right' }}>
                   2020년 05월 30일
                   <br />
                   14:00 ~

--- a/src/frameworks/web/components/organisms/Landing/LandingJoin.tsx
+++ b/src/frameworks/web/components/organisms/Landing/LandingJoin.tsx
@@ -30,7 +30,7 @@ export default class LandingJoin extends React.PureComponent {
       <ScreenClassRender render={(sClass: string) => (
         <JoinContainer id="landingJoin">
           <div style={{ textAlign: 'center', padding: ['lg', 'xl'].includes(sClass) ? '64px 0' : '32px 0' }}>
-            <Label type="H4">JOIN US</Label>
+            <Label type={['lg', 'xl'].includes(sClass) ? 'H4' : 'MobileH4'}>JOIN US</Label>
           </div>
           <Row justify="center" style={{ margin: '0' }}>
             <Col xs={10} lg={9}>
@@ -55,7 +55,9 @@ export default class LandingJoin extends React.PureComponent {
                 padding: ['lg', 'xl'].includes(sClass) ? '64px 0' : '32px 0',
               }}
             >
-              <Label type="P1">※ 올해 본 행사는 온라인에서 진행되는 관계로, 도서관 및 봉사자 신청을 받지 않습니다.</Label>
+              <Label type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}>
+                ※ 올해 본 행사는 온라인에서 진행되는 관계로, 도서관 및 봉사자 신청을 받지 않습니다.
+              </Label>
             </Col>
           </Row>
         </JoinContainer>

--- a/src/frameworks/web/components/organisms/Landing/LandingJoin.tsx
+++ b/src/frameworks/web/components/organisms/Landing/LandingJoin.tsx
@@ -6,6 +6,11 @@ import ContentsBox from 'frameworks/web/components/atoms/ContentsBox/ContentsBox
 import Button from 'frameworks/web/components/atoms/Button/Button';
 import { Row, Col, ScreenClassRender } from 'react-grid-system';
 
+const MaxContainer = styled.div`
+  max-width: 1280px;
+  margin: 0 auto;
+`;
+
 const JoinContainer = styled.div`
   background: ${theme.color.secondary.Snow};
 `;
@@ -27,42 +32,47 @@ const notYetAlert = () => {
 export default class LandingJoin extends React.PureComponent {
   render() {
     return (
-      <ScreenClassRender render={(sClass: string) => (
-        <JoinContainer id="landingJoin">
-          <div style={{ textAlign: 'center', padding: ['lg', 'xl'].includes(sClass) ? '64px 0' : '32px 0' }}>
-            <Label type={['lg', 'xl'].includes(sClass) ? 'H4' : 'MobileH4'}>JOIN US</Label>
-          </div>
-          <Row justify="center" style={{ margin: '0' }}>
-            <Col xs={10} lg={9}>
-              <ContentsBox isDarkBackground>
-                <div style={{ padding: ['lg', 'xl'].includes(sClass) ? '24px 0 48px 0' : '' }}>
-                  <JoinIllust src="speaker-illustration.png" alt="Join us" />
-                  <div style={{ display: 'flex', justifyContent: 'center', width: '100%' }}>
-                    <Button
-                      type={['lg', 'xl'].includes(sClass) ? 'wide' : 'mobilewide'}
-                      label="강연자 신청하기"
-                      isPrimary
-                      onClick={notYetAlert}
-                    />
-                  </div>
-                </div>
-              </ContentsBox>
-            </Col>
-            <Col
-              xs={8}
-              style={{
-                textAlign: 'center',
-                padding: ['lg', 'xl'].includes(sClass) ? '64px 0' : '32px 0',
-              }}
-            >
-              <Label type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}>
-                ※ 올해 본 행사는 온라인에서 진행되는 관계로, 도서관 및 봉사자 신청을 받지 않습니다.
-              </Label>
-            </Col>
-          </Row>
-        </JoinContainer>
-      )}
-      />
+      <div style={{ backgroundColor: theme.color.secondary.Snow }}>
+        <MaxContainer>
+          <ScreenClassRender render={(sClass: string) => (
+            <JoinContainer id="landingJoin">
+              <div style={{ textAlign: 'center', padding: ['lg', 'xl'].includes(sClass) ? '64px 0' : '32px 0' }}>
+                <Label type={['lg', 'xl'].includes(sClass) ? 'H4' : 'MobileH4'}>JOIN US</Label>
+              </div>
+              <Row justify="center" style={{ margin: '0' }}>
+                <Col xs={10} lg={9}>
+                  <ContentsBox isDarkBackground>
+                    <div style={{ padding: ['lg', 'xl'].includes(sClass) ? '24px 0 48px 0' : '' }}>
+                      <JoinIllust src="speaker-illustration.png" alt="Join us" />
+                      <div style={{ display: 'flex', justifyContent: 'center', width: '100%' }}>
+                        <Button
+                          type={['lg', 'xl'].includes(sClass) ? 'wide' : 'mobilewide'}
+                          label="강연자 신청하기"
+                          isPrimary
+                          onClick={notYetAlert}
+                        />
+                      </div>
+                    </div>
+                  </ContentsBox>
+                </Col>
+                <Col
+                  xs={9}
+                  lg={8}
+                  style={{
+                    textAlign: 'center',
+                    padding: ['lg', 'xl'].includes(sClass) ? '64px 0' : '32px 0',
+                  }}
+                >
+                  <Label type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}>
+                    ※ 올해 본 행사는 온라인에서 진행되는 관계로, 도서관 및 봉사자 신청을 받지 않습니다.
+                  </Label>
+                </Col>
+              </Row>
+            </JoinContainer>
+          )}
+          />
+        </MaxContainer>
+      </div>
     );
   }
 }

--- a/src/frameworks/web/components/organisms/Landing/LandingSponsor.tsx
+++ b/src/frameworks/web/components/organisms/Landing/LandingSponsor.tsx
@@ -39,7 +39,12 @@ export default class LandingSponsor extends React.PureComponent {
               margin: ['lg', 'xl'].includes(sClass) ? '64px 0' : '32px 0',
             }}
           >
-            <Label type="H4" color={theme.color.primary.Azure}>HOW TO SPONSOR</Label>
+            <Label
+              type={['lg', 'xl'].includes(sClass) ? 'H4' : 'MobileH3'}
+              color={theme.color.primary.Azure}
+            >
+              HOW TO SPONSOR
+            </Label>
           </div>
           <Row
             justify="center"
@@ -55,14 +60,20 @@ export default class LandingSponsor extends React.PureComponent {
             </Col>
             <Col xs={10} lg={6} xl={5}>
               <SponsorLabelContainer>
-                <Label type="P1" style={{ marginBottom: '8px' }}>
+                <Label
+                  type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}
+                  style={{ marginBottom: '8px' }}
+                >
                   늘 그렇듯이 이런 행사에는 산업체, 개인들의 열화와 같은 지지, 그리고 물심양면의 후원이 필요합니다.
                 </Label>
-                <Label type="P1" style={{ marginBottom: '8px' }}>
+                <Label
+                  type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}
+                  style={{ marginBottom: '8px' }}
+                >
                   현금 후원도 받지만, 도서관과 행사 참여 어린이들에게 주실 서적, 기념품, 그리고 봉사자들을 위 후원품을 보내주시면 저희가 전달해드립니다.
                   아주 작은 후원이라도 감사히 생각하며 개인, 회사, 기관의 소중한 후원이 우리의 미래를 밝게 할 것입니다.
                 </Label>
-                <Label type="P1">
+                <Label type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}>
                   또한 후원사들의 명단 & 로고를 널리 알려 이 소중한 행사에 같이 해주심을 기억하겠습니다.
                 </Label>
               </SponsorLabelContainer>

--- a/src/frameworks/web/components/organisms/Landing/LandingSponsor.tsx
+++ b/src/frameworks/web/components/organisms/Landing/LandingSponsor.tsx
@@ -7,6 +7,11 @@ import {
   Row, Col, Visible, Hidden, ScreenClassRender,
 } from 'react-grid-system';
 
+const MaxContainer = styled.div`
+  max-width: 1280px;
+  margin: 0 auto;
+`;
+
 const SponsorIllust = styled.img`
   max-width: 540px;
   max-height: 450px;
@@ -17,7 +22,6 @@ const SponsorIllust = styled.img`
 `;
 
 const SponsorLabelContainer = styled.div`
-  padding: 40px;
   margin-bottom: 32px;
   border-radius: 20px;
   background-color: #f4f4f4;
@@ -31,87 +35,89 @@ const SponsorInfoContainer = styled.div`
 export default class LandingSponsor extends React.PureComponent {
   render() {
     return (
-      <ScreenClassRender render={(sClass: string) => (
-        <div id="landingSponsor">
-          <div
-            style={{
-              textAlign: 'center',
-              margin: ['lg', 'xl'].includes(sClass) ? '64px 0' : '32px 0',
-            }}
-          >
-            <Label
-              type={['lg', 'xl'].includes(sClass) ? 'H4' : 'MobileH3'}
-              color={theme.color.primary.Azure}
+      <MaxContainer>
+        <ScreenClassRender render={(sClass: string) => (
+          <div id="landingSponsor">
+            <div
+              style={{
+                textAlign: 'center',
+                margin: ['lg', 'xl'].includes(sClass) ? '64px 0' : '32px 0',
+              }}
             >
-              HOW TO SPONSOR
-            </Label>
+              <Label
+                type={['lg', 'xl'].includes(sClass) ? 'H4' : 'MobileH3'}
+                color={theme.color.primary.Azure}
+              >
+                HOW TO SPONSOR
+              </Label>
+            </div>
+            <Row
+              justify="center"
+              align="center"
+              style={{ margin: ['lg', 'xl'].includes(sClass) ? '0 0 120px 0' : '0 0 32px 0' }}
+            >
+              <Col xs={12} md={6} lg={5} xl={5}>
+                <SponsorIllust
+                  src="sponsor-illustration.png"
+                  alt="About Somul"
+                  style={{ marginBottom: ['lg', 'xl'].includes(sClass) ? '0' : '32px' }}
+                />
+              </Col>
+              <Col xs={11} lg={6} xl={5}>
+                <SponsorLabelContainer style={{ padding: ['lg', 'xl'].includes(sClass) ? '40px' : '24px' }}>
+                  <Label
+                    type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}
+                    style={{ marginBottom: '8px' }}
+                  >
+                    늘 그렇듯이 이런 행사에는 산업체, 개인들의 열화와 같은 지지, 그리고 물심양면의 후원이 필요합니다.
+                  </Label>
+                  <Label
+                    type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}
+                    style={{ marginBottom: '8px' }}
+                  >
+                    현금 후원도 받지만, 도서관과 행사 참여 어린이들에게 주실 서적, 기념품, 그리고 봉사자들을 위 후원품을 보내주시면 저희가 전달해드립니다.
+                    아주 작은 후원이라도 감사히 생각하며 개인, 회사, 기관의 소중한 후원이 우리의 미래를 밝게 할 것입니다.
+                  </Label>
+                  <Label type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}>
+                    또한 후원사들의 명단 & 로고를 널리 알려 이 소중한 행사에 같이 해주심을 기억하겠습니다.
+                  </Label>
+                </SponsorLabelContainer>
+                <Visible xl lg>
+                  <SponsorInfoContainer>
+                    <Tag>물품 발송 주소</Tag>
+                    <Label type="P2" style={{ margin: '3px 0 0 16px' }}>
+                      서울특별시 성동구 왕십리로 130, 10층(KCC프리미어타워)
+                      <br />
+                      한국코드클럽위원회, 소프트웨어에 물들다 담당자
+                    </Label>
+                  </SponsorInfoContainer>
+                  <SponsorInfoContainer>
+                    <Tag>관계자 이메일</Tag>
+                    <Label type="P2" style={{ margin: '3px 0 0 20px' }}>
+                      somul.may@gmail.com
+                    </Label>
+                  </SponsorInfoContainer>
+                </Visible>
+                <Hidden xl lg>
+                  <div style={{ textAlign: 'center' }}>
+                    <Tag>물품 발송 주소</Tag>
+                    <Label type="P2" style={{ margin: '16px 0 24px 0' }}>
+                      서울특별시 성동구 왕십리로 130, 10층(KCC프리미어타워)
+                      <Visible md><br /></Visible>
+                      한국코드클럽위원회, 소프트웨어에 물들다 담당자
+                    </Label>
+                    <Tag>관계자 이메일</Tag>
+                    <Label type="P2" style={{ margin: '16px 0' }}>
+                      somul.may@gmail.com
+                    </Label>
+                  </div>
+                </Hidden>
+              </Col>
+            </Row>
           </div>
-          <Row
-            justify="center"
-            align="center"
-            style={{ margin: ['lg', 'xl'].includes(sClass) ? '0 0 64px 0' : '0 0 32px 0' }}
-          >
-            <Col xs={8} md={6} lg={5} xl={5}>
-              <SponsorIllust
-                src="sponsor-illustration.png"
-                alt="About Somul"
-                style={{ marginBottom: ['lg', 'xl'].includes(sClass) ? '0' : '32px' }}
-              />
-            </Col>
-            <Col xs={10} lg={6} xl={5}>
-              <SponsorLabelContainer>
-                <Label
-                  type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}
-                  style={{ marginBottom: '8px' }}
-                >
-                  늘 그렇듯이 이런 행사에는 산업체, 개인들의 열화와 같은 지지, 그리고 물심양면의 후원이 필요합니다.
-                </Label>
-                <Label
-                  type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}
-                  style={{ marginBottom: '8px' }}
-                >
-                  현금 후원도 받지만, 도서관과 행사 참여 어린이들에게 주실 서적, 기념품, 그리고 봉사자들을 위 후원품을 보내주시면 저희가 전달해드립니다.
-                  아주 작은 후원이라도 감사히 생각하며 개인, 회사, 기관의 소중한 후원이 우리의 미래를 밝게 할 것입니다.
-                </Label>
-                <Label type={['lg', 'xl'].includes(sClass) ? 'P1' : 'MobileP1'}>
-                  또한 후원사들의 명단 & 로고를 널리 알려 이 소중한 행사에 같이 해주심을 기억하겠습니다.
-                </Label>
-              </SponsorLabelContainer>
-              <Visible xl lg>
-                <SponsorInfoContainer>
-                  <Tag>물품 발송 주소</Tag>
-                  <Label type="P2" style={{ margin: '3px 0 0 16px' }}>
-                    서울특별시 성동구 왕십리로 130, 10층(KCC프리미어타워)
-                    <br />
-                    한국코드클럽위원회, 소프트웨어에 물들다 담당자
-                  </Label>
-                </SponsorInfoContainer>
-                <SponsorInfoContainer>
-                  <Tag>관계자 이메일</Tag>
-                  <Label type="P2" style={{ margin: '3px 0 0 20px' }}>
-                    somul.may@gmail.com
-                  </Label>
-                </SponsorInfoContainer>
-              </Visible>
-              <Hidden xl lg>
-                <div style={{ textAlign: 'center' }}>
-                  <Tag>물품 발송 주소</Tag>
-                  <Label type="P2" style={{ margin: '16px 0 24px 0' }}>
-                    서울특별시 성동구 왕십리로 130, 10층(KCC프리미어타워)
-                    <Visible md><br /></Visible>
-                    한국코드클럽위원회, 소프트웨어에 물들다 담당자
-                  </Label>
-                  <Tag>관계자 이메일</Tag>
-                  <Label type="P2" style={{ margin: '16px 0' }}>
-                    somul.may@gmail.com
-                  </Label>
-                </div>
-              </Hidden>
-            </Col>
-          </Row>
-        </div>
-      )}
-      />
+        )}
+        />
+      </MaxContainer>
     );
   }
 }

--- a/src/interfaces/frameworks/web/components/atoms/Label/ILabel.ts
+++ b/src/interfaces/frameworks/web/components/atoms/Label/ILabel.ts
@@ -1,4 +1,5 @@
-type labelType = 'H1' | 'H2' | 'H3' | 'H4' | 'H5' | 'H6' | 'P1' | 'P2';
+type labelType = 'MobileH1' | 'MobileH2' | 'MobileH3' | 'MobileH4' | 'MobileP1' | 'MobileP2' |
+                  'H1' | 'H2' | 'H3' | 'H4' | 'H5' | 'H6' | 'P1' | 'P2';
 type markType = 'none' | 'underline' | 'full';
 
 export interface ILabelMark {


### PR DESCRIPTION
## 무엇을 변경했나요?

- 유정님께서 주신 랜딩페이지 피드백을 수정하는 PR입니다.
	- [x] PC/Mobile에서 About somul의 하이라이트 색상이 다름 (#FFF0A6으로 변경)
	- [x] PC에서 How to sponsor 아래 마진이 다름 (일러스트 기준 120px)
	- [x] PC에서 메인 이미지에서 일러스트와 글자의 간격이 좀 멀어 보임
	- [x] Mobile 폰트 사이즈가 모바일 컴포넌트에 맞게 조정되지 않았습니다.
	- [x] Mobile 메인 이미지의 "소프트웨어에 물들다" 로고의 사이즈, 날짜의 위치가 다르고, 일러스트의 사이즈가 줄어듬.
	- [x] Mobile의 How to sponsor 일러스트의 사이즈가 줄어듬.
	- [x] Mobile의 About somul의 description에 위아래 단락의 정렬이 다름. (현재 위는 가운데정렬 아래는 왼쪽정렬)
	- [ ] ~~PC 상단 네비게이션에 "신청하기"버튼을 눌렀을때 하단의 "신청하기"로 스크롤되는데, 바로 "신청하기" 페이지로 넘어가기~~ (신청하기 페이지 추가 시 구현)
	- [x] 세로 그리드 간격관련


- 추가적으로 이전 PR인 카드 컴포넌트에 업데이트된 라벨 컴포넌트를 적용했습니다.
