### PR TITLE
fix: 랜딩페이지 요청사항 수정 (2차)

### DIFF
--- a/src/frameworks/web/components/atoms/Button/Button.tsx
+++ b/src/frameworks/web/components/atoms/Button/Button.tsx
@@ -15,9 +15,11 @@ const BaseButton = styled.button`
   border-radius: 10px;
   font-size: 16px;
   transition: all 0.2s;
-  
-  &:hover {
-     background-color: ${(props: IBaseButton) => (props.isPrimary ? theme.color.primary.Salmon : theme.color.secondary.Nickel)};
+
+  @media (hover: hover) {
+    &:hover {
+      background-color: ${(props: IBaseButton) => (props.isPrimary ? theme.color.primary.Salmon : theme.color.secondary.Nickel)};
+    }
   }
 `;
 

--- a/src/frameworks/web/components/atoms/ContentSwitcher/ContentSwitcher.tsx
+++ b/src/frameworks/web/components/atoms/ContentSwitcher/ContentSwitcher.tsx
@@ -20,9 +20,11 @@ const BaseContentButton = styled.button`
   font-size: 16px;
   transition: all 0.2s;
   
-  &:hover {
-     background-color: ${theme.color.primary.Sky};
-     color: ${theme.color.primary.White} !important;
+  @media (hover: hover) {
+    &:hover {
+      background-color: ${theme.color.primary.Sky};
+      color: ${theme.color.primary.White} !important;
+    }
   }
 `;
 

--- a/src/frameworks/web/components/atoms/Dropdown/Dropdown.tsx
+++ b/src/frameworks/web/components/atoms/Dropdown/Dropdown.tsx
@@ -51,9 +51,10 @@ const DropdownList = styled.li<_IDropdownList>`
   transition: 0.1s background;
   
   color: ${(props) => (props.isSelected ? theme.color.primary.Azure : theme.color.primary.Black)};
-  
-  &:hover {
-    background: ${theme.color.secondary.Snow};
+  @media (hover: hover) {
+    &:hover {
+      background: ${theme.color.secondary.Snow};
+    }
   }
 `;
 

--- a/src/frameworks/web/components/atoms/LoginButton/LoginButton.tsx
+++ b/src/frameworks/web/components/atoms/LoginButton/LoginButton.tsx
@@ -15,8 +15,10 @@ const LoginButtonContainer = styled.div`
   width: 255px;
   height: 56px;
   
-  &:hover {
-     background-color: ${theme.color.secondary.Snow};
+  @media (hover: hover) {
+    &:hover {
+      background-color: ${theme.color.secondary.Snow};
+    }
   }
 `;
 

--- a/src/frameworks/web/components/atoms/Select/Select.tsx
+++ b/src/frameworks/web/components/atoms/Select/Select.tsx
@@ -28,8 +28,10 @@ const SelectElement = styled.button`
   border-top-right-radius: ${(props: ISelectElement) => (props.edge === 'right' ? '10px' : '4px')};
   border-bottom-right-radius: ${(props: ISelectElement) => (props.edge === 'right' ? '10px' : '4px')};
   
-  &:hover {
-    border: solid 2px ${theme.color.primary.Azure};
+  @media (hover: hover) {
+    &:hover {
+      border: solid 2px ${theme.color.primary.Azure};
+    }
   }
 `;
 

--- a/src/frameworks/web/components/organisms/Header/Header.tsx
+++ b/src/frameworks/web/components/organisms/Header/Header.tsx
@@ -59,7 +59,7 @@ export default class Header extends React.PureComponent {
               <Visible xl>
                 <HeaderMenuContainer>
                   <a href="#landingAbout" style={{ textDecoration: 'none' }}>
-                    <Label type="H5" onClick={notYetAlert}>소물이란?</Label>
+                    <Label type="H5">소물이란?</Label>
                   </a>
                   <Label type="H5" onClick={notYetAlert}>강연정보</Label>
                   <a href="#landingJoin" style={{ textDecoration: 'none' }}>

--- a/src/frameworks/web/components/organisms/Landing/LandingBanner.tsx
+++ b/src/frameworks/web/components/organisms/Landing/LandingBanner.tsx
@@ -72,7 +72,9 @@ export default class LandingBanner extends React.PureComponent {
                       <Label type="H4" color={theme.color.primary.White} style={{ margin: '40px 0' }}>
                         2020년 05월 30일 14:00 ~
                       </Label>
-                      <a href="#landingAbout"><Button isPrimary={false} label="자세히보기" onClick={() => undefined} /></a>
+                      <a href="#landingAbout" style={{ textDecoration: 'none' }}>
+                        <Button isPrimary={false} label="자세히보기" onClick={() => undefined} />
+                      </a>
                     </Hidden>
                   </Col>
                   <Visible xs sm>
@@ -91,7 +93,9 @@ export default class LandingBanner extends React.PureComponent {
                     paddingBottom: '40px',
                   }}
                   >
-                    <a href="#landingAbout"><Button isPrimary={false} label="자세히보기" onClick={() => undefined} /></a>
+                    <a href="#landingAbout" style={{ textDecoration: 'none' }}>
+                      <Button isPrimary={false} label="자세히보기" onClick={() => undefined} />
+                    </a>
                   </div>
                 </Visible>
               </BannerContainer>

--- a/src/frameworks/web/components/organisms/Landing/LandingBanner.tsx
+++ b/src/frameworks/web/components/organisms/Landing/LandingBanner.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import styled from 'styled-components';
+// eslint-disable-next-line no-unused-vars
+import styled, { StyledComponent } from 'styled-components';
 import theme from 'theme';
 import Label from 'frameworks/web/components/atoms/Label/Label';
 import Button from 'frameworks/web/components/atoms/Button/Button';
@@ -11,6 +12,39 @@ const BannerContainer = styled.div`
   background-color: ${theme.color.primary.Azure};
   background-image: url("main-illustration.png");
   background-repeat: no-repeat;
+`;
+
+const BannerContainerSmall = styled(BannerContainer)`
+  margin: 0 16px;
+  background-position: center 65%;
+  background-size: 328px 293px;
+`;
+
+const BannerContainerMedium = styled(BannerContainer)`
+  margin: 0 16px;
+  background-position: right 339px;
+  background-size: 589px 526px;
+`;
+
+const BannerContainerLarge = styled(BannerContainer)`
+  margin: 0 110px 0 180px;
+  background-position: right 114px;
+  background-size: 589px 526px;
+`;
+
+const RowContainerSmall = styled.div`
+  width: 100%;
+  padding: 32px 0 348px 0;
+`;
+
+const RowContainerMedium = styled.div`
+  width: 100%;
+  padding: 64px 0 533px 57px;
+`;
+
+const RowContainerLarge = styled.div`
+  width: 100%;
+  padding: 120px 0 253px 0;
 `;
 
 const MaxContainer = styled.div`
@@ -32,59 +66,57 @@ export default class LandingBanner extends React.PureComponent {
       <div style={{ backgroundColor: theme.color.primary.Azure }}>
         <MaxContainer>
           <ScreenClassRender render={(sClass: string) => {
-            // xs, sm : 2, md : 1, lg, xl: 0
-            let sClassNum: number;
-            let contentPadding: string;
-            let imgPosition: string;
+            let BannerContainerFit: StyledComponent<'div', any, {}, never>;
+            let RowContainerFit: StyledComponent<'div', any, {}, never>;
             if (['lg', 'xl'].includes(sClass)) {
-              sClassNum = 0;
-              contentPadding = '120px 0 253px 0';
-              imgPosition = 'right 114px';
+              BannerContainerFit = BannerContainerLarge;
+              RowContainerFit = RowContainerLarge;
             } else if (sClass === 'md') {
-              sClassNum = 1;
-              contentPadding = '64px 0 533px 57px';
-              imgPosition = 'right 339px';
+              BannerContainerFit = BannerContainerMedium;
+              RowContainerFit = RowContainerMedium;
             } else {
-              sClassNum = 2;
-              contentPadding = '32px 0 348px 0';
-              imgPosition = 'center 65%';
+              BannerContainerFit = BannerContainerSmall;
+              RowContainerFit = RowContainerSmall;
             }
             return (
-              <BannerContainer
-                style={{
-                  margin: sClassNum === 0 ? '0 110px 0 180px' : '0 16px',
-                  backgroundPosition: imgPosition,
-                  backgroundSize: sClassNum === 2 ? '328px 293px' : '589px 526px',
-                }}
-              >
-                <Row
-                  justify={sClassNum === 0 ? 'between' : 'center'}
-                  align={sClassNum === 0 ? 'start' : 'end'}
-                  style={{
-                    width: '100%',
-                    padding: contentPadding,
-                    margin: '0',
-                  }}
-                >
-                  <Col xs={12} sm={12} lg={9} style={{ textAlign: sClassNum === 2 ? 'center' : 'initial' }}>
-                    <BannerTitleImg src="main-contents-title.svg" alt="소프트웨어에 물들다" />
-                    <Hidden xs sm>
-                      <Label type="H4" color={theme.color.primary.White} style={{ margin: '40px 0' }}>
-                        2020년 05월 30일 14:00 ~
-                      </Label>
-                      <a href="#landingAbout" style={{ textDecoration: 'none' }}>
-                        <Button isPrimary={false} label="자세히보기" onClick={() => undefined} />
-                      </a>
-                    </Hidden>
-                  </Col>
-                  <Visible xs sm>
-                    <Col xs={12}>
-                      <Label type={sClassNum === 2 ? 'MobileP1' : 'H4'} color={theme.color.primary.White} style={{ textAlign: 'center', marginTop: '32px' }}>
-                        2020년 05월 30일 14:00 ~
-                      </Label>
+              <BannerContainerFit>
+                <RowContainerFit>
+                  <Row
+                    justify={['lg', 'xl'].includes(sClass) ? 'between' : 'center'}
+                    align={['lg', 'xl'].includes(sClass) ? 'start' : 'end'}
+                    style={{
+                      width: '100%',
+                      margin: '0',
+                    }}
+                  >
+                    <Col
+                      xs={12}
+                      lg={9}
+                      style={{ textAlign: ['xs', 'sm'].includes(sClass) ? 'center' : 'initial' }}
+                    >
+                      <BannerTitleImg src="main-contents-title.svg" alt="소프트웨어에 물들다" />
+                      <Hidden xs sm>
+                        <Label type="H4" color={theme.color.primary.White} style={{ margin: '40px 0' }}>
+                          2020년 05월 30일 14:00 ~
+                        </Label>
+                        <a href="#landingAbout" style={{ textDecoration: 'none' }}>
+                          <Button isPrimary={false} label="자세히보기" onClick={() => undefined} />
+                        </a>
+                      </Hidden>
                     </Col>
-                  </Visible>
-                </Row>
+                    <Visible xs sm>
+                      <Col xs={12}>
+                        <Label
+                          type={['xs', 'sm'].includes(sClass) ? 'MobileP1' : 'H4'}
+                          color={theme.color.primary.White}
+                          style={{ textAlign: 'center', marginTop: '32px' }}
+                        >
+                          2020년 05월 30일 14:00 ~
+                        </Label>
+                      </Col>
+                    </Visible>
+                  </Row>
+                </RowContainerFit>
                 <Visible xs sm>
                   <div style={{
                     display: 'flex',
@@ -98,7 +130,7 @@ export default class LandingBanner extends React.PureComponent {
                     </a>
                   </div>
                 </Visible>
-              </BannerContainer>
+              </BannerContainerFit>
             );
           }}
           />

--- a/src/frameworks/web/components/organisms/Landing/LandingSponsor.tsx
+++ b/src/frameworks/web/components/organisms/Landing/LandingSponsor.tsx
@@ -102,9 +102,13 @@ export default class LandingSponsor extends React.PureComponent {
                   <div style={{ textAlign: 'center' }}>
                     <Tag>물품 발송 주소</Tag>
                     <Label type="P2" style={{ margin: '16px 0 24px 0' }}>
-                      서울특별시 성동구 왕십리로 130, 10층(KCC프리미어타워)
+                      서울특별시 성동구 왕십리로 130, 10층 (KCC프리미어타워)
                       <Visible md><br /></Visible>
-                      한국코드클럽위원회, 소프트웨어에 물들다 담당자
+                      {' '}
+                      한국코드클럽위원회,
+                      <Visible xs sm><br /></Visible>
+                      {' '}
+                      소프트웨어에 물들다 담당자
                     </Label>
                     <Tag>관계자 이메일</Tag>
                     <Label type="P2" style={{ margin: '16px 0' }}>


### PR DESCRIPTION
## 무엇을 변경했나요?

- 유정님이 추가적으로 요청하신 수정사항을 수정했습니다.
	- [ ] ~웹 네비게이션이 상단에 고정되어있지 않음~ (추후 수정할 예정입니다)
	- [x] 상단 네비게이션에 '소물이란?' 버튼을 클릭해도 추후 공개 메세지가 뜸
	- [x] 모바일 버튼이 한번 누르면 hover 상태에서 다시 원상태로 복구되지 않음
		- 추가적으로 hover 관련된 모든 컴포넌트를 모바일에서는 hover가 작동되지 않게 수정했습니다.
	- [x] How to sponsor > 물품 발송 주소' 영역에 맨 마지막 글자 '자' 한 글자만로 내려와있음
		- 해당 수정사항은 모바일 환경일 때(윈도우 폭이 축소되었을 때) 개행되도록 수정했습니다.
- 추가적으로 이전 이슈(#25)에서 언급하신 사항을 수정했습니다.