### PR TITLE
fix: Open Graph에서 https 주소를 가져오지 못하는 오류 수정

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,8 @@
     <meta property="og:title" content="5월, 소프트웨어에 물들다." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.somul.kr" />
-    <meta property="og:image" content="https://www.somul.kr/illust/somul-opengraph.png" />
+    <meta property="og:image" content="http://somul.kr.s3-website.ap-northeast-2.amazonaws.com/illust/somul-opengraph.png" />
+    <meta property="og:image:secure_url" content="https://www.somul.kr/illust/somul-opengraph.png" />
     <meta property="og:description" content="전국의 도서관에서 소프트웨어를 주제로 한날 한시에 진행되는 강연 프로젝트입니다." />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png"/>
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json"/>


### PR DESCRIPTION
## 무엇을 변경했나요?

- Open Graph image 주소가 https일때 문제가 생겨 수정했습니다.
- 참고 : https://stackoverflow.com/questions/8855361/fb-opengraph-ogimage-not-pulling-images-possibly-https
