### PR TITLE
fix: 특정 화면에서 로딩 컴포넌트가 한쪽으로 쏠리는 오류 수정

### DIFF
--- a/src/frameworks/web/components/organisms/SignIn/SignInCard.tsx
+++ b/src/frameworks/web/components/organisms/SignIn/SignInCard.tsx
@@ -91,7 +91,7 @@ export default function SignInCard(): React.ReactElement {
   };
 
   return (
-    <div>
+    <>
       <SignInContainer isDarkBackground>
         <Label type="H4" color={theme.color.primary.Azure} style={{ textAlign: 'center' }}>
           SIGN IN
@@ -137,6 +137,6 @@ export default function SignInCard(): React.ReactElement {
         </SignButtonContainer>
       </SignInContainer>
       {isLoading && <Loading />}
-    </div>
+    </>
   );
 }

--- a/src/frameworks/web/components/organisms/SignUp/SignUpComplete.tsx
+++ b/src/frameworks/web/components/organisms/SignUp/SignUpComplete.tsx
@@ -44,7 +44,7 @@ export default function SignUpComplete(): React.ReactElement {
   };
 
   return (
-    <div>
+    <>
       <SingleCard
         title="인증메일이 전송되었습니다!"
         buttonLabel={['재전송', '확인']}
@@ -59,6 +59,6 @@ export default function SignUpComplete(): React.ReactElement {
         </Label>
       </SingleCard>
       {isLoading && <Loading />}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## 무엇을 변경했나요?

- 특정 화면에서 로딩 컴포넌트가 오른쪽으로 쏠리게 나오는 현상을 수정했습니다.
  - #66 을 통해 일부 페이지에 flex 속성을 넣었는데 이로 인해 로딩 컴포넌트의 너비 높의 100프로가 flex로 인해 브라우져 전체를 덮지 못했습니다.
  - 이후 로딩 컴포넌트를 추가할때 다음과 같이 한 div에 넣지 않고 분리해서 추가해주시면 감사드리겠습니다.
