### PR TITLE
fix: DividedCard가 오른쪽 구역에 맞지 않게 왼쪽 구역의 높이가 조절되지 않는 오류 수정

### DIFF
--- a/src/frameworks/web/components/molecules/DividedCard/DividedCard.tsx
+++ b/src/frameworks/web/components/molecules/DividedCard/DividedCard.tsx
@@ -19,7 +19,7 @@ const CardContainer = styled(ContentsBox)`
 
 const LeftContainer = styled.div`
   width: 380px;
-  height: 100%;
+  height: auto;
   border-top-left-radius: 30px;
   border-bottom-left-radius: 30px;
   padding: ${(props: IDividedCardLeft) => props.leftPadding ?? '80px 0'};


### PR DESCRIPTION
## 무엇을 변경했나요?

- DividedCard의 오른쪽 구역이 왼쪽구역과 맞지 않게 조절되는 오류를 수정했습니다.

## 관련 항목 (PR, 이슈, 링크 등) 이 있으면 적어주세요!

- #78 번 이슈와 연관있음
Closed #78
